### PR TITLE
Allow different config per device when programming multiple devices

### DIFF
--- a/Apps/MfgToolLib/MfgToolLib.cpp
+++ b/Apps/MfgToolLib/MfgToolLib.cpp
@@ -1323,7 +1323,7 @@ DWORD ParseUclXml(MFGLIB_VARS *pLibVars)
 
 		strTemp = (*it)->GetAttrValue(_T("body"));
 		strTemp = ReplaceKeywords(strTemp);
-		pOpCmd->SetBodyString(strTemp);
+		pOpCmd->SetTemplateBodyString(strTemp);
 		pOpCmd->SetDescString((*it)->GetText());
 
 		strTemp = (*it)->GetAttrValue(_T("ifdev"));
@@ -1434,15 +1434,26 @@ COpCommand::~COpCommand()
 {
 }
 
-void COpCommand::SetBodyString(CString &str)
+void COpCommand::SetBodyString(int index, CString &str)
 {
-	m_bodyString = str;
+	m_bodyString[index] = str;
 }
 
-CString COpCommand::GetBodyString()
+void COpCommand::SetTemplateBodyString(CString &str)
 {
-	return m_bodyString;
+	m_templateBodyString = str;
 }
+
+CString COpCommand::GetBodyString(int index)
+{
+	return m_bodyString[index];
+}
+
+CString COpCommand::GetTemplateBodyString()
+{
+	return m_templateBodyString;
+}
+
 
 void COpCommand::SetDescString(CString &str)
 {
@@ -1615,7 +1626,7 @@ UINT COpCmd_Boot::ExecuteCommand(int index)
 			_uiInfo.CommandStatus = COMMAND_STATUS_EXECUTE_ERROR;
 			_uiInfo.bUpdateDescription = TRUE;
 			CString strDesc;
-			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(), m_FileName);
+			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(index), m_FileName);
 			_tcscpy(_uiInfo.strDescription, strDesc.GetBuffer());
 			strDesc.ReleaseBuffer();
 			((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
@@ -1632,7 +1643,7 @@ UINT COpCmd_Boot::ExecuteCommand(int index)
 			_uiInfo.CommandStatus = COMMAND_STATUS_EXECUTE_ERROR;
 			_uiInfo.bUpdateDescription = TRUE;
 			CString strDesc;
-			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(), m_FileName);
+			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(index), m_FileName);
 			_tcscpy(_uiInfo.strDescription, strDesc.GetBuffer());
 			strDesc.ReleaseBuffer();
 			((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
@@ -1654,7 +1665,7 @@ UINT COpCmd_Boot::ExecuteCommand(int index)
 			_uiInfo.CommandStatus = COMMAND_STATUS_EXECUTE_ERROR;
 			_uiInfo.bUpdateDescription = TRUE;
 			CString strDesc;
-			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(), m_FileName);
+			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(index), m_FileName);
 			_tcscpy(_uiInfo.strDescription, strDesc.GetBuffer());
 			strDesc.ReleaseBuffer();
 			((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
@@ -1682,7 +1693,7 @@ UINT COpCmd_Boot::ExecuteCommand(int index)
 			_uiInfo.CommandStatus = COMMAND_STATUS_EXECUTE_ERROR;
 			_uiInfo.bUpdateDescription = TRUE;
 			CString strDesc;
-			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(), m_FileName);
+			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(index), m_FileName);
 			_tcscpy(_uiInfo.strDescription, strDesc.GetBuffer());
 			strDesc.ReleaseBuffer();
 			((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
@@ -1787,7 +1798,7 @@ UINT COpCmd_Init::ExecuteCommand(int index)
 			_uiInfo.CommandStatus = COMMAND_STATUS_EXECUTE_ERROR;
 			_uiInfo.bUpdateDescription = TRUE;
 			CString strDesc;
-			strDesc.Format(_T("\"Init\" body=\"%s\" error, file=\"%s\""), GetBodyString(), m_FileName);
+			strDesc.Format(_T("\"Init\" body=\"%s\" error, file=\"%s\""), GetBodyString(index), m_FileName);
 			_tcscpy(_uiInfo.strDescription, strDesc.GetBuffer());
 			strDesc.ReleaseBuffer();
 			((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
@@ -1804,7 +1815,7 @@ UINT COpCmd_Init::ExecuteCommand(int index)
 			_uiInfo.CommandStatus = COMMAND_STATUS_EXECUTE_ERROR;
 			_uiInfo.bUpdateDescription = TRUE;
 			CString strDesc;
-			strDesc.Format(_T("\"Init\" body=\"%s\" error, file=\"%s\""), GetBodyString(), m_FileName);
+			strDesc.Format(_T("\"Init\" body=\"%s\" error, file=\"%s\""), GetBodyString(index), m_FileName);
 			_tcscpy(_uiInfo.strDescription, strDesc.GetBuffer());
 			strDesc.ReleaseBuffer();
 			((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
@@ -2144,9 +2155,9 @@ UINT COpCmd_Push::ExecuteCommand(int index)
 {
 	CString strMsg;
 	if (m_FileName.IsEmpty())
-		strMsg.Format(_T("ExecuteCommand--Push[WndIndex:%d], Body is %s"), index, m_bodyString);
+		strMsg.Format(_T("ExecuteCommand--Push[WndIndex:%d], Body is %s"), index, GetBodyString(index));
 	else
-		strMsg.Format(_T("ExecuteCommand--Push[WndIndex:%d], Body is %s, File is %s"), index, m_bodyString, m_FileName);
+		strMsg.Format(_T("ExecuteCommand--Push[WndIndex:%d], Body is %s, File is %s"), index, GetBodyString(index), m_FileName);
 
 	LogMsg(LOG_MODULE_MFGTOOL_LIB, LOG_LEVEL_NORMAL_MSG, _T("%s"), strMsg);
 
@@ -2164,7 +2175,7 @@ UINT COpCmd_Push::ExecuteCommand(int index)
 	strDesc.ReleaseBuffer();
 	((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
 
-	CString csCmdBody = GetBodyString();
+	CString csCmdBody = GetBodyString(index);
 	CString csCmdText = GetDescString();
 	DWORD retValue = MFGLIB_ERROR_SUCCESS;
 
@@ -2429,7 +2440,7 @@ void COpCmd_Blhost::CloseFileMapping()
 UINT COpCmd_Blhost::ExecuteCommand(int index)
 {
 	CString strMsg;
-	strMsg.Format(_T("ExecuteCommand--Blhost[WndIndex:%d], Body is %s"), index, m_bodyString);
+	strMsg.Format(_T("ExecuteCommand--Blhost[WndIndex:%d], Body is %s"), index, GetBodyString(index));
 	LogMsg(LOG_MODULE_MFGTOOL_LIB, LOG_LEVEL_NORMAL_MSG, _T("%s"), strMsg);
 
 	UI_UPDATE_INFORMATION _uiInfo;
@@ -2446,7 +2457,7 @@ UINT COpCmd_Blhost::ExecuteCommand(int index)
 	strDesc.ReleaseBuffer();
 	((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
 
-	CString csCmdBody = GetBodyString();
+	CString csCmdBody = GetBodyString(index);
 	CString csCmdText = GetDescString();
 
 	if (csCmdText.CompareNoCase(_T("Done")) == 0)
@@ -3306,7 +3317,7 @@ void ReplaceAllUsbPortKeyWords(MFGLIB_VARS *pLibVars, int WndIndex)
 		{
 			for (auto& it : stateIt.second)
 			{
-				it->SetBodyString(ReplaceUsbPortKeywords(it->GetBodyString(), hub, port));
+				it->SetBodyString(WndIndex, ReplaceUsbPortKeywords(it->GetTemplateBodyString(), hub, port));
 			}
 		}
 	}

--- a/Apps/MfgToolLib/MfgToolLib.h
+++ b/Apps/MfgToolLib/MfgToolLib.h
@@ -168,8 +168,10 @@ public:
 	COpCommand();
 	virtual ~COpCommand();
 	virtual UINT ExecuteCommand(int index);
-	virtual void SetBodyString(CString &str);
-	virtual CString GetBodyString();
+	virtual void SetBodyString(int index, CString &str);
+	virtual void SetTemplateBodyString(CString &str);
+	virtual CString GetBodyString(int index);
+	virtual CString GetTemplateBodyString();
 	virtual void SetDescString(CString &str);
 	virtual CString GetDescString();
 	virtual void SetIfDevString(CString &str);
@@ -179,7 +181,8 @@ public:
 	INSTANCE_HANDLE m_pLibVars;
 
 protected:
-	CString m_bodyString;
+	std::map<int, CString> m_bodyString;
+	CString m_templateBodyString;
 	CString m_descString;
 	CString m_ifdev;
 	CString m_ifhab;


### PR DESCRIPTION
Before this patch, when programming multiple devices with different
configuration (mac addresses fx.), we would hit an issue where all
devices would get the same configuration.
The reason for this was that even though the configuration was updated
for each device, the output of the update was stored in a single class
variable (m_bodyString), which was getting overwritten by the lastest update.

So this patch:
1. Sets up a template variable (m_templateBodyString) including
getters/setters, which is used to store the original XML.
2. Changes the m_bodyString to be a map, based on the WndIndex of the
device and update references to it.
3. Make sure that nothing is directly using the class variable
(m_bodyString), but instead all operations use the getters and setters.